### PR TITLE
Permission denied

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,6 +11,8 @@ use std::path::Path;
 use std::path::PathBuf;
 use toml;
 use TimeTracker;
+use watcher;
+use std::sync::mpsc::channel;
 
 pub struct Configuration {
     user_config_path: PathBuf, // this file should not be read outside this module
@@ -78,6 +80,19 @@ pub fn get_config() -> Configuration {
 impl<'a> TimeTracker<'a> {
     pub fn print_config(&self) {
         println!("{}", self.config);
+        println!("Starting self test..");
+        let (tx, _rx) = channel();
+        for track_path in &self.config.track_paths {
+            match watcher::get_watcher(track_path, tx.clone()) {
+                Ok(_) => {
+                    println!("Successfully added watcher for path {}", track_path.to_string_lossy());
+                },
+                Err(err) => {
+                    println!("Error {} adding watcher for path {:?}", err, track_path.to_string_lossy());
+                },
+            };
+        }
+        println!("Completed self test.");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod clear;
 mod config;
 mod schedule;
 mod track;
+mod watcher;
 
 use config::Configuration;
 

--- a/src/track/mod.rs
+++ b/src/track/mod.rs
@@ -1,4 +1,4 @@
-use notify::{DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::DebouncedEvent;
 use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -11,9 +11,6 @@ use std::time::Duration;
 use std::time::Instant;
 use std::time::SystemTime;
 use TimeTracker;
-use std::sync::mpsc::Sender;
-use notify::FsEventWatcher;
-use notify;
 use watcher;
 
 impl<'a> TimeTracker<'a> {

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -2,10 +2,9 @@ use notify::{DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::PathBuf;
 use std::time::Duration;
 use std::sync::mpsc::Sender;
-use notify::FsEventWatcher;
 use notify;
 
-pub fn get_watcher(track_path: &PathBuf, tx: Sender<DebouncedEvent>) -> Result<FsEventWatcher, notify::Error> {
+pub fn get_watcher(track_path: &PathBuf, tx: Sender<DebouncedEvent>) -> Result<RecommendedWatcher, notify::Error> {
     let mut watcher: RecommendedWatcher =
         Watcher::new(tx, Duration::from_secs(0))?;
     watcher.watch(track_path, RecursiveMode::Recursive)?;

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -1,16 +1,6 @@
 use notify::{DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
-use std::collections::HashSet;
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::Path;
 use std::path::PathBuf;
-use std::sync::mpsc::channel;
-use std::sync::mpsc::TryRecvError;
-use std::thread;
 use std::time::Duration;
-use std::time::Instant;
-use std::time::SystemTime;
-use TimeTracker;
 use std::sync::mpsc::Sender;
 use notify::FsEventWatcher;
 use notify;

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -1,0 +1,24 @@
+use notify::{DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::HashSet;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::mpsc::channel;
+use std::sync::mpsc::TryRecvError;
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
+use std::time::SystemTime;
+use TimeTracker;
+use std::sync::mpsc::Sender;
+use notify::FsEventWatcher;
+use notify;
+
+pub fn get_watcher(track_path: &PathBuf, tx: Sender<DebouncedEvent>) -> Result<FsEventWatcher, notify::Error> {
+    let mut watcher: RecommendedWatcher =
+        Watcher::new(tx, Duration::from_secs(0))?;
+    watcher.watch(track_path, RecursiveMode::Recursive)?;
+
+    Ok(watcher)
+}


### PR DESCRIPTION
Fixes #2 by handling error when tracking and exposing data to user through `timetrack config`.